### PR TITLE
fixed intendation on property 'interval'

### DIFF
--- a/easybox-config-schema.coffee
+++ b/easybox-config-schema.coffee
@@ -11,7 +11,7 @@ module.exports = {
       type: "string"
       default: ""
       required: yes
-	interval:
+    interval:
       description: "The time in ms, for querying the router"
       type: "number"
       default: 60


### PR DESCRIPTION
When I specify an interval in my config.json I get the following error:

```
19:27:07.947 [pimatic] Loading plugin: "pimatic-easybox" (0.1.2)
19:27:09.426 [pimatic] Invalid config of pimatic-easybox: Property "interval" is not a valid property
```

I think this could be caused by the file [easybox-config-schema.coffee](https://github.com/Xento/pimatic-easybox/blob/5dc23b3ca7654a109720e272e5c031b1541f2437/easybox-config-schema.coffee) where there is too much intendation on the property `interval`.
